### PR TITLE
Fix vscode intellisense errors caused by cmake and add clang format file

### DIFF
--- a/board/.clang-format
+++ b/board/.clang-format
@@ -1,0 +1,9 @@
+# Linux kernel coding style
+BasedOnStyle: LLVM
+IndentWidth: 8       # Kernel uses tabs, but clang-format handles tabs
+UseTab: ForIndentation
+ColumnLimit: 80
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Linux

--- a/board/CMakeLists.txt
+++ b/board/CMakeLists.txt
@@ -8,23 +8,23 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Export compile_commands.json for clangd
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Public headers for BSP 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-
 # Collect all BSP source files
 file(GLOB BSP_SOURCES
     ${CMAKE_SOURCE_DIR}/src/bsp/*.c
 )
 
-# Create a static library
+# Create a static library for BSP
 add_library(bsp STATIC ${BSP_SOURCES})
+
+# Tell CMake that anything linking bsp gets the include folder
+target_include_directories(bsp PUBLIC ${CMAKE_SOURCE_DIR}/include)
 
 # Collect all app source files
 file(GLOB APP_SOURCES
     ${CMAKE_SOURCE_DIR}/src/app/*.c
 )
 
-# Create executable
+# Create executable for the app
 add_executable(${PROJECT_NAME} ${APP_SOURCES})
 
 # Link BSP library to app


### PR DESCRIPTION
Intellisense was tweaking for me because of cmake (red underlines on things that compile) and clangd. Compiling and running program still works the same with this change.

Add clang format file. Just took the linux kernel convention as a guideline.