### PR TITLE
Make adjustments to clang format and add README to list dependencies

### DIFF
--- a/board/.clang-format
+++ b/board/.clang-format
@@ -1,9 +1,22 @@
-# Linux kernel coding style
+# Clang-Format configuration for SnowAngel-UAV
 BasedOnStyle: LLVM
-IndentWidth: 8       # Kernel uses tabs, but clang-format handles tabs
-UseTab: ForIndentation
+
+# Indentation
+UseTab: ForIndentation      # Use tabs instead of spaces
+TabWidth: 4                 # Width of a tab character
+IndentWidth: 4              # Indentation level for nested blocks
+
+# Line length
 ColumnLimit: 80
+
+# Alignment options
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
+
+# Control flow formatting
 AllowShortIfStatementsOnASingleLine: false
-BreakBeforeBraces: Linux
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+
+# Brace style
+BreakBeforeBraces: Allman

--- a/board/README.md
+++ b/board/README.md
@@ -1,0 +1,34 @@
+# Project Setup
+
+## Prerequisites
+
+This project requires the following tools to be installed on your system:
+
+- **GCC** – C compiler  
+- **G++** – C++ compiler  
+- **clang-format** – Code formatter  
+- **clangd** – Language server for C/C++ (used by IDEs like VS Code)
+
+## Installation
+
+### Ubuntu / Debian
+```bash
+sudo apt update
+sudo apt install build-essential clang-format clangd -y
+```
+
+### macOS (with Homebrew)
+```bash
+brew install gcc clang-format clangd
+```
+
+### Verify Installation
+```bash
+gcc --version
+g++ --version
+clang-format --version
+clangd --version
+```
+
+### Note
+On VS Code, make you see clangd at the bottom left of your screen on your status bar. If you don't, reload your editor.

--- a/board/src/app/main.c
+++ b/board/src/app/main.c
@@ -3,6 +3,11 @@
 
 int main()
 {
-    printf("Hello World!\n");
-    foo();
+	printf("Hello World!\n");
+	foo();
+
+	if (1)
+	{
+		printf("hello");
+	}
 }


### PR DESCRIPTION
- C/C++ now uses tabs with tab width of 4 spaces instead of 8
- Opening braces start on the next line
- README for board software dependencies