### PR TITLE
Changes to clang format

### DIFF
--- a/board/.clang-format
+++ b/board/.clang-format
@@ -7,7 +7,7 @@ TabWidth: 4                 # Width of a tab character
 IndentWidth: 4              # Indentation level for nested blocks
 
 # Line length
-ColumnLimit: 80
+ColumnLimit: 100
 
 # Alignment options
 AlignConsecutiveAssignments: false
@@ -16,7 +16,10 @@ AlignConsecutiveDeclarations: false
 # Control flow formatting
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
+AllowShortFunctionsOnASingleLine: Empty
 
 # Brace style
 BreakBeforeBraces: Allman
+
+# Access specifiers (public/private/protected)
+AccessModifierOffset: -4

--- a/board/src/bsp/ops_fmcw.hpp
+++ b/board/src/bsp/ops_fmcw.hpp
@@ -1,12 +1,12 @@
 /**
- * 
+ *
  * Name: ops_fmcw.hpp
  * Author: Karran Dhillon
- * 
+ *
  * This file describes the private interface for the OPS-243C FMCW radar sensor.
- * 
+ *
  * Date: October 2025
- * 
+ *
  * Copyright 2025 SnowAngel-UAV
  */
 
@@ -19,15 +19,16 @@
 class OPS_FMCW : public FMCW_RADAR_SENSOR
 {
 public:
-    OPS_FMCW(uint8_t usb_port);
+	OPS_FMCW(uint8_t usb_port);
 
-    int8_t fmcw_radar_sensor_init()  override;
-    int8_t fmcw_radar_sensor_read_rx_signal(fmcw_waveform_data_t *data) override;
-    int8_t fmcw_radar_sensor_start_tx_signal() override;
-    int8_t fmcw_radar_sensor_stop_tx_signal()  override;
-    ~OPS_FMCW() override {}
+	int8_t fmcw_radar_sensor_init() override;
+	int8_t fmcw_radar_sensor_read_rx_signal(fmcw_waveform_data_t *data) override;
+	int8_t fmcw_radar_sensor_start_tx_signal() override;
+	int8_t fmcw_radar_sensor_stop_tx_signal() override;
+	~OPS_FMCW() override {}
+
 private:
-    uint8_t usb_port;
+	uint8_t usb_port;
 };
 
 #endif // #ifndef OPS_FMCW_H


### PR DESCRIPTION
- Change column limit from 80 to 100 (still fits nicely on your typical editor and 80 feels too small sometimes)
- Make access modifiers like public/private not indent (stay on same line) - this was doing something weird when I tried formatting C++ code
- Make empty functions have their braces like `{}` instead of creating new lines
- Format fmcw sensor header with new rules

@karrandhillon If you approve I'm just going to force merge because I don't think this is something worth reviewing.