### PR TITLE
Function to instantiate the singleton radar sensor

### DIFF
--- a/board/include/bsp/fmcw_radar_sensor.hpp
+++ b/board/include/bsp/fmcw_radar_sensor.hpp
@@ -52,4 +52,6 @@ public:
 
 //----------------------------------------------------------------
 
+FMCW_RADAR_SENSOR *instantiate_fmcw_radar_sensor(uint8_t usb_port);
+
 #endif // #ifndef FMCW_RADAR_SENSOR_H

--- a/board/src/bsp/ops_fmcw.cpp
+++ b/board/src/bsp/ops_fmcw.cpp
@@ -152,3 +152,8 @@ int8_t OPS_FMCW::read_response(std::string *response)
 	// stub for now.
 	return 0;
 }
+
+FMCW_RADAR_SENSOR *instantiate_fmcw_radar_sensor(uint8_t usb_port)
+{
+	return OPS_FMCW::get_fmcw_radar_instance(usb_port);
+}


### PR DESCRIPTION
In the app layer just call `FMCW_RADAR_SENSOR *radar_ptr = instantiate_fmcw_radar_sensor(0/*whatever port*/);`